### PR TITLE
Remove deprecation warnings with last Redis

### DIFF
--- a/lib/sidekiq/limit_fetch/global/monitor.rb
+++ b/lib/sidekiq/limit_fetch/global/monitor.rb
@@ -46,10 +46,10 @@ module Sidekiq::LimitFetch::Global
 
     def update_heartbeat(ttl)
       Sidekiq.redis do |it|
-        it.multi do
-          it.set heartbeat_key, true
-          it.sadd PROCESS_SET, Selector.uuid
-          it.expire heartbeat_key, ttl
+        it.multi do |pipeline|
+          pipeline.set heartbeat_key, true
+          pipeline.sadd PROCESS_SET, Selector.uuid
+          pipeline.expire heartbeat_key, ttl
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,13 +11,13 @@ RSpec.configure do |config|
     Sidekiq::Queue.reset_instances!
     Sidekiq.redis do |it|
       clean_redis = ->(queue) do
-        it.pipelined do
-          it.del "limit_fetch:limit:#{queue}"
-          it.del "limit_fetch:process_limit:#{queue}"
-          it.del "limit_fetch:busy:#{queue}"
-          it.del "limit_fetch:probed:#{queue}"
-          it.del "limit_fetch:pause:#{queue}"
-          it.del "limit_fetch:block:#{queue}"
+        it.pipelined do |pipeline|
+          pipeline.del "limit_fetch:limit:#{queue}"
+          pipeline.del "limit_fetch:process_limit:#{queue}"
+          pipeline.del "limit_fetch:busy:#{queue}"
+          pipeline.del "limit_fetch:probed:#{queue}"
+          pipeline.del "limit_fetch:pause:#{queue}"
+          pipeline.del "limit_fetch:block:#{queue}"
         end
       end
 


### PR DESCRIPTION
Pipelining commands on a Redis instance is deprecated and will be removed in Redis 5.0.0.